### PR TITLE
Pylint warnings will now fail travis build

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,3 +1,6 @@
 [MASTER]
 load-plugins=pylint_flask
 generated-members=objects,id
+
+[MESSAGES CONTROL]
+disable=R0903,fixme,locally-disabled,cyclic-import

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ before_script:
   - bower install
 script:
   - nosetests
-  - pylint -E bikeshare_app
-  - pylint -E tests
+  - pylint bikeshare_app
+  - pylint tests
 env:
   - BIKESHARE_APP_SECRET="\xf3& \x98\x9cy\xf6\xde6\x91\xd0\x8a\xd6\xbfF[\x86'6+J\x1cs\xfa"
     BIKESHARE_ADMIN_PASSWORD=DummyPassword123

--- a/bikeshare_app/__init__.py
+++ b/bikeshare_app/__init__.py
@@ -1,5 +1,5 @@
 """Initialize the bikeshare app"""
-# pylint: disable=no-name-in-module,import-error,invalid-name,wrong-import-position
+# pylint: disable=invalid-name,wrong-import-position
 from os import getenv
 from flask import Flask
 from flask.ext.mongoengine import MongoEngine

--- a/bikeshare_app/models.py
+++ b/bikeshare_app/models.py
@@ -3,7 +3,6 @@ from datetime import date
 from bikeshare_app import db
 
 
-# pylint: disable=too-few-public-methods
 class Profile(db.EmbeddedDocument):
     """Embedded user profile"""
     height = db.IntField(required=True)

--- a/bikeshare_app/views.py
+++ b/bikeshare_app/views.py
@@ -7,9 +7,11 @@ from . import login_manager
 from .models import ActiveShare
 
 
+# pylint: disable=invalid-name
+# We need to use id for flask-login but pylint doesnt like it
 class User(flask_login.UserMixin):
     """User model for login."""
-    pass
+    id = None
 
 
 @login_manager.user_loader

--- a/tests/basic_tests.py
+++ b/tests/basic_tests.py
@@ -1,3 +1,4 @@
+"""Basic unit tests"""
 from os import getenv
 import flask
 from bikeshare_app import app
@@ -10,6 +11,8 @@ def test_home():
 
 
 class TestAdmin():
+    """Tests for the admin control panel"""
+    # pylint: disable=missing-docstring
     @classmethod
     def setup_class(cls):
         print(__name__, 'TestAdmin.setup_class() ------')
@@ -20,6 +23,7 @@ class TestAdmin():
 
     def setup(self):
         """Get test client for HTTP methods"""
+        # pylint: disable=attribute-defined-outside-init
         self.app = app.test_client()
 
     def login(self, email, password):
@@ -37,6 +41,7 @@ class TestAdmin():
 
     def test_admin_log_in(self):
         """Test the login endpoint to access admin"""
+        # pylint: disable=invalid-name
         rv = self.login('admin', 'MIDNA')
         assert b'Available Bikes' in rv.data
         rv = self.admin()


### PR DESCRIPTION
R0903 is the "too few public methods" warning. I think that one is stupid so I disabled it. "fixme" is disabled so we don't get warnings for adding `TODO`'s.
